### PR TITLE
feat: support tls.Server type

### DIFF
--- a/src/core/improvedServer.ts
+++ b/src/core/improvedServer.ts
@@ -3,11 +3,12 @@ import config from '~/config'
 import ImprovedServer from '~/interface/improvedServer'
 import IStatus from '~/interface/status'
 import onRequest from '~/util/onRequest'
+import HttpServer from '../interface/httpServer'
 import SocketsPool from './socketsPool'
 
 const { livenessEndpoint, readinessEndpoint } = config
 
-const improvedServer = (server: http.Server, serverStatus: IStatus): ImprovedServer => {
+const improvedServer = (server: HttpServer, serverStatus: IStatus): ImprovedServer => {
   const { healthCheck } = config
   const socketsPool = SocketsPool()
   const secureSocketsPool = SocketsPool()

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from 'events'
-import * as http from 'http'
 import ICore from '~/interface/core'
 import init from '~/util/init'
 import shutdown from '~/util/shutdown'
+import HttpServer from '../interface/httpServer'
 import ImprovedServer from './improvedServer'
 import Status from './status'
 
-const core = (server: http.Server): ICore => {
+const core = (server: HttpServer): ICore => {
   const _emitter = new EventEmitter()
   const status = Status(_emitter)
   const _server = ImprovedServer(server, status)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import * as http from 'http'
 import { makeOptions } from '~/config'
 import GracefulServerCore from '~/core'
 import State from '~/core/state'
 import IGracefulServer from '~/interface/gracefulServer'
 import IGracefulServerOptions from '~/interface/gracefulServerOptions'
+import HttpServer from './interface/httpServer'
 
-const buildGracefulServer = (server: http.Server, options?: IGracefulServerOptions): IGracefulServer => {
+const buildGracefulServer = (server: HttpServer, options?: IGracefulServerOptions): IGracefulServer => {
   makeOptions(options)
   const gracefulServer = GracefulServerCore(server).init()
   return {

--- a/src/interface/httpServer.ts
+++ b/src/interface/httpServer.ts
@@ -1,0 +1,6 @@
+import * as http from 'http'
+import * as tls from 'tls'
+
+type HttpServer = http.Server | tls.Server
+
+export default HttpServer

--- a/src/interface/improvedServer.ts
+++ b/src/interface/improvedServer.ts
@@ -1,5 +1,14 @@
 import * as http from 'http'
+import * as tls from 'tls'
 
-export default interface ImprovedServer extends http.Server {
+interface ImprovedRegularServer extends http.Server {
   stop: () => Promise<void>
 }
+
+interface ImprovedSecureServer extends tls.Server {
+  stop: () => Promise<void>
+}
+
+type ImprovedServer = ImprovedRegularServer | ImprovedSecureServer
+
+export default ImprovedServer


### PR DESCRIPTION
This PR affects only typings.

I've been using GracefulServer with Fastify http2 and noticed type incompatibility when using a secure server.
This PR fixes it.

I've tried to follow your code style, but if you'd like some changes I'll gladly do it.