### PR TITLE
Feature/implement grace time to improve kube integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,13 +306,14 @@ where `State` is an enum that contains, `STARTING`, `READY`, `SHUTTING_DOWN` and
 
 All of the below options are optional.
 
-| Name              |            Type            | Default |                                                      Description |
-| ----------------- | :------------------------: | :-----: | ---------------------------------------------------------------: |
-| closePromises     | (() => Promise<unknown>)[] |   []    |                    The functions to run when the API is stopping |
-| timeout           |           number           |  1000   | The time in milliseconds to wait before shutting down the server |
-| healthCheck       |          boolean           |  true   |    Enable/Disable the default endpoints (liveness and readiness) |
-| livenessEndpoint  |           string           |  /live  |                                            The liveness endpoint |
-| readinessEndpoint |           string           | /ready  |                                           The readiness endpoint |
+| Name              |            Type            | Default |                                                              Description |
+| ----------------- | :------------------------: | :-----: | -----------------------------------------------------------------------: |
+| closePromises     | (() => Promise<unknown>)[] |   []    |                            The functions to run when the API is stopping |
+| timeout           |           number           |  1000   |         The time in milliseconds to wait before shutting down the server |
+| healthCheck       |          boolean           |  true   |            Enable/Disable the default endpoints (liveness and readiness) |
+| livenessEndpoint  |           string           |  /live  |                                                    The liveness endpoint |
+| readinessEndpoint |           string           | /ready  |                                                   The readiness endpoint |
+| gracePeriod       |           number           |    0    | Number of seconds to wait before stopping to accept the incoming traffic |
 
 ### GracefulServer Instance
 
@@ -433,6 +434,9 @@ CMD ["node", "./build/src/main.js"]
 ```
 
 ## Integration with Kubernetes
+
+In the following example, you have to setup the gracePeriod to 5 seconds because you set up the readiness timeout to 5 seconds.
+[(Related to this issue)](https://github.com/gquittet/graceful-server/issues/5)
 
 ```yml
 readinessProbe:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,7 +6,8 @@ const options: IOptions = {
   timeout: 1000,
   healthCheck: true,
   livenessEndpoint: '/live',
-  readinessEndpoint: '/ready'
+  readinessEndpoint: '/ready',
+  gracePeriod: 0
 }
 let canOverride = true
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const MILLISECONDS_IN_ONE_SECOND = 1000

--- a/src/interface/options.ts
+++ b/src/interface/options.ts
@@ -4,4 +4,5 @@ export default interface IOptions {
   healthCheck: boolean
   livenessEndpoint: string
   readinessEndpoint: string
+  gracePeriod: number
 }

--- a/src/util/shutdown.ts
+++ b/src/util/shutdown.ts
@@ -1,13 +1,18 @@
 import config from '~/config'
+import { MILLISECONDS_IN_ONE_SECOND } from '~/constants'
 import State from '~/core/state'
 import ICore from '~/interface/core'
 import ImprovedServer from '~/interface/improvedServer'
 import sleep from './sleep'
 
 const shutdown = (server: ImprovedServer, parent: ICore) => async (type: string, value: number, body?: Error) => {
-  const { timeout, closePromises } = config
+  const { timeout, closePromises, gracePeriod } = config
 
   const error: Error = body && body.message ? body : new Error(type)
+
+  if (gracePeriod > 0) {
+    await sleep(gracePeriod * MILLISECONDS_IN_ONE_SECOND)
+  }
 
   parent.status.set(State.SHUTTING_DOWN, error)
   await sleep(timeout)

--- a/tests/config/config.test.ts
+++ b/tests/config/config.test.ts
@@ -31,4 +31,10 @@ describe('config', () => {
     const { readinessEndpoint } = defaultConfig
     expect(readinessEndpoint).toBe('/ready')
   })
+
+  it('should have a default gracePeriod at 0', () => {
+    expect.assertions(1)
+    const { gracePeriod } = defaultConfig
+    expect(gracePeriod).toBe(0)
+  })
 })


### PR DESCRIPTION
Add `gracePeriod` to the configuration.  
By default it will be disabled (value of 0) and you can set up the number of seconds related of your kubernetes configuration.

---
