### PR TITLE
chore: add kubernetes to IGracefulServerOptions interface

### DIFF
--- a/src/interface/gracefulServerOptions.ts
+++ b/src/interface/gracefulServerOptions.ts
@@ -2,6 +2,7 @@ export default interface IGracefulServerOptions {
   closePromises?: (() => Promise<unknown>)[]
   timeout?: number
   healthCheck?: boolean
+  kubernetes?: boolean
   livenessEndpoint?: string
   readinessEndpoint?: string
 }


### PR DESCRIPTION
Add kubernetes field to IGracefulServerOptions as shown here:

https://github.com/gquittet/graceful-server#igracefulserveroptions