### PR TITLE
Make close function as public

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,7 +4,6 @@ import { EventEmitter } from "events";
 import ImprovedServer from "#core/improvedServer";
 import Status from "#core/status";
 import init from "#util/init";
-import shutdown from "#util/shutdown";
 
 const core = (server: Server): ICore => {
   const _emitter = new EventEmitter();
@@ -15,8 +14,8 @@ const core = (server: Server): ICore => {
     init: function () {
       return init(this);
     },
-    shutdown: function (type: string, value: number, error?: Error) {
-      return shutdown(_server, this)(type, value, error);
+    stop: function (args?: { type?: string; value: number; body?: Error }) {
+      return _server.stop(args);
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     on: (name: string, callback: (...args: any[]) => void) => _emitter.on(name, callback),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const buildGracefulServer = (server: Server, options?: IGracefulServerOptions): 
     isReady: () => gracefulServer.status.isReady(),
     setReady: () => gracefulServer.status.setReady(),
     on: gracefulServer.on,
+    stop: async () => await gracefulServer.stop(),
   };
 };
 

--- a/src/interface/core.ts
+++ b/src/interface/core.ts
@@ -4,7 +4,7 @@ import type { EventEmitter } from "events";
 export type ICore = {
   status: IStatus;
   init: () => ICore;
-  shutdown: (type: string, value: number, error?: Error) => Promise<void>;
+  stop: (args?: { type?: string; value: number; body?: Error }) => Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on: (name: string, callback: (...args: any[]) => void) => EventEmitter;
 };

--- a/src/interface/gracefulServer.ts
+++ b/src/interface/gracefulServer.ts
@@ -5,4 +5,5 @@ export type IGracefulServer = {
   setReady: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on: (name: string, callback: (...args: any[]) => void) => EventEmitter;
+  stop: () => Promise<void>;
 };

--- a/src/util/init.ts
+++ b/src/util/init.ts
@@ -6,7 +6,7 @@ import signals from "#core/signals";
 const init = (parent: ICore) => {
   for (const signal of signals) {
     (process as NodeJS.EventEmitter).on(signal.type, async (body) => {
-      await parent.shutdown(signal.type, signal.code, body);
+      await parent.stop({ type: signal.type, value: signal.code, body });
     });
   }
   return parent;


### PR DESCRIPTION
The goal is to allow end-user to close the server and trigger the close promises callbacks.

Issue: #25