### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   <a href="https://www.npmjs.com/package/@gquittet/graceful-server" target="_blank" rel="noopener">
     <img src="https://img.shields.io/npm/dw/@gquittet/graceful-server" alt="npmjs download">
   </a>
+  <a href="https://dependents.info/gquittet/graceful-server" target="_blank" rel="noopener">
+    <img src="https://dependents.info/gquittet/graceful-server/badge" alt="network dependents" />
+  </a>
   <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=JN3XLTQCX3NR8&source=url" target="_blank" rel="noopener">
     <img src="https://img.shields.io/badge/Donate-PayPal-green.svg" alt="Donate with PayPal">
   </a>
@@ -30,6 +33,7 @@
 ---
 
 - [Features](#features)
+- [Used by](#used-by)
 - [Requirements](#requirements)
 - [Installation](#installation)
   - [NPM](#npm)
@@ -63,6 +67,12 @@
 ✔ Dependency-free.
 
 ✔ KISS code base.
+
+## Used by
+
+<a href="https://dependents.info/gquittet/graceful-server" target="_blank" rel="noopener">
+  <img src="https://dependents.info/gquittet/graceful-server/image" alt="network dependents" />
+</a>
 
 ## Requirements
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="678" alt="image" src="https://github.com/user-attachments/assets/2e89954e-5555-48e9-aaa0-01625054518f" />

Please feel free to close the PR if you don't want to have this!